### PR TITLE
feat: Apply Windows 95 style redesign to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
     <meta name="twitter:creator" content="@Kazu_Hani">
 
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="styles/main.css">
     <script>
@@ -105,11 +104,11 @@
     }
     </script>
 </head>
-<body class="bg-gradient-to-br from-slate-900 to-slate-700 text-white flex flex-col items-center min-h-screen p-4">
+<body class="flex flex-col items-center min-h-screen p-4">
 
     <!-- Table of Contents -->
-    <div id="tableOfContents" class="toc-is-loading hidden lg:block fixed top-1/4 right-4 w-36 bg-slate-800/90 backdrop-blur-sm p-1 rounded-md shadow-xl z-[999] max-h-[60vh] overflow-y-auto">
-        <h3 class="text-base font-semibold text-indigo-300 mb-1 border-b border-slate-700 pb-1">Contents</h3>
+    <div id="tableOfContents" class="toc-is-loading hidden lg:block fixed top-1/4 right-4 w-36 p-1 z-[999] max-h-[60vh] overflow-y-auto">
+        <h3 class="text-base font-semibold mb-1 border-b pb-1">Contents</h3>
         <ul id="tocList" class="space-y-1">
             <!-- Links will be dynamically inserted by JavaScript -->
         </ul>
@@ -120,77 +119,77 @@
     <i id="sunIcon" class="fas fa-sun time-indicator-icon fade-in-on-scroll"></i>
 
     <!-- Moved Time and Availability Status Here -->
-    <div id="currentTimeContainer" class="text-slate-300 text-base mb-1 fade-in-on-scroll">
+    <div id="currentTimeContainer" class="text-base mb-1 fade-in-on-scroll">
         <span class="font-bold text-lg">My current time is </span><span id="currentTime" class="text-lg">Loading...</span>
     </div>
-    <div id="availabilityStatusContainer" class="text-slate-400 text-sm mb-6 fade-in-on-scroll">
+    <div id="availabilityStatusContainer" class="text-sm mb-4 fade-in-on-scroll"> <!-- Reduced mb-6 to mb-4 -->
         <span id="availabilityMessage" class="font-bold text-base">Checking availability...</span>
     </div>
 
 
-    <div class="container bg-slate-800 shadow-2xl rounded-xl p-6 md:p-10 text-center">
-        <div class="mb-6">
+    <div class="container p-4 md:p-6 text-center"> <!-- Reduced p-6 md:p-10 to p-4 md:p-6 -->
+        <div class="mb-4"> <!-- Reduced mb-6 to mb-4 -->
             <div class="profile-image-wrapper">
-                <img src="Images/com.png" alt="Kazu Hani, profile picture" id="profilePic" class="profile-picture w-32 h-32 md:w-40 md:h-40 rounded-full mx-auto border-2 border-indigo-500 shadow-lg object-cover fade-in-on-scroll" onerror="this.onerror=null; this.src='https://placehold.co/150x150/6366f1/e0e7ff?text=Image+Not+Found'; this.alt='Placeholder image for Kazu Hani';">
+                <img src="Images/com.png" alt="Kazu Hani, profile picture" id="profilePic" class="profile-picture w-32 h-32 md:w-40 md:h-40 mx-auto border-2 object-cover fade-in-on-scroll" onerror="this.onerror=null; this.src='https://placehold.co/150x150/6366f1/e0e7ff?text=Image+Not+Found'; this.alt='Placeholder image for Kazu Hani';">
                 <p id="dragonText">Do Not The Dragon</p>
             </div>
         </div>
 
         <div class="mb-6 text-center "> <!-- Added fade-in-on-scroll to the parent div -->
-            <h1 id="kazuName" class="text-3xl md:text-4xl font-bold mb-2 text-indigo-400 fade-in-on-scroll">Kazu Hani</h1>
-            <p class="text-slate-300 bio-text text-base md:text-lg mt-2 mb-1 fade-in-on-scroll" id="bioTextParagraph">
+            <h1 id="kazuName" class="text-3xl md:text-4xl font-bold mb-2 fade-in-on-scroll">Kazu Hani</h1>
+            <p class="bio-text text-base md:text-lg mt-2 mb-1 fade-in-on-scroll" id="bioTextParagraph">
                 <span class="highlight-text">Welcome to my personal hub!</span>
             </p>
-            <div class="mt-4 mb-4 fade-in-on-scroll">
+            <div class="mt-3 mb-3 fade-in-on-scroll"> <!-- Reduced mt-4 mb-4 to mt-3 mb-3 -->
                  <a href="https://vgen.co/c/kazu-hani/kazu-hani" target="_blank" rel="noopener noreferrer"
-                   class="info-button inline-block bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-lg text-sm shadow-md" title="Learn more about Kazu Hani on VGen">
+                   class="info-button inline-block font-medium text-sm" title="Learn more about Kazu Hani on VGen"> <!-- Removed py-2 px-4 -->
                     More info about Kazu
                 </a>
             </div>
         </div>
 
-        <div id="birthdayCountdown" class="text-slate-300 fade-in-on-scroll">
+        <div id="birthdayCountdown" class="fade-in-on-scroll mb-2"> <!-- Added mb-2 -->
             Birthday is in <span id="countdownTimer">Loading...</span>
         </div>
 
-        <div id="ageDisplay" class="text-slate-300 fade-in-on-scroll">
+        <div id="ageDisplay" class="fade-in-on-scroll mb-4"> <!-- Added mb-4 -->
             I am currently <span id="currentAge"></span> years old.
         </div>
 
-        <div class="space-y-4 mb-8"> <!-- fade-in-on-scroll removed from parent -->
+        <div class="space-y-2 mb-6"> <!-- Reduced space-y-4 to space-y-2, mb-8 to mb-6 -->
             <a href="https://x.com/Kazu_Hani" target="_blank" rel="noopener noreferrer"
-               class="social-icon flex items-center justify-center w-full bg-sky-500 hover:bg-sky-600 text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="Follow Kazu Hani on X (formerly Twitter)">
+               class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="Follow Kazu Hani on X (formerly Twitter)"> <!-- Removed py-3 px-4 -->
                 <img src="Images/twitter_logo.png" alt="Twitter Logo" class="w-6 h-6 mr-3" onerror="this.onerror=null; this.src='https://placehold.co/24x24/1DA1F2/ffffff?text=T&font=roboto'; this.alt='Twitter Placeholder';">
                 <span>Twitter</span>
             </a>
             <a href="https://www.tiktok.com/@kazu_hani" target="_blank" rel="noopener noreferrer"
-               class="social-icon flex items-center justify-center w-full bg-black hover:bg-gray-800 text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="Watch Kazu Hani on TikTok">
+               class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="Watch Kazu Hani on TikTok"> <!-- Removed py-3 px-4 -->
                 <img src="Images/tiktok_logo.png" alt="TikTok Logo" class="w-6 h-6 mr-3" onerror="this.onerror=null; this.src='https://placehold.co/24x24/000000/ffffff?text=TT&font=roboto'; this.alt='TikTok Placeholder';">
                 <span>TikTok</span>
             </a>
             <a href="https://www.youtube.com/@Kazu_Hani" target="_blank" rel="noopener noreferrer"
-               class="social-icon flex items-center justify-center w-full bg-red-600 hover:bg-red-700 text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="Subscribe to Kazu Hani on YouTube">
+               class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="Subscribe to Kazu Hani on YouTube"> <!-- Removed py-3 px-4 -->
                 <img src="Images/youtube_logo.png" alt="YouTube Logo" class="w-6 h-6 mr-3" onerror="this.onerror=null; this.src='https://placehold.co/24x24/FF0000/ffffff?text=YT&font=roboto'; this.alt='YouTube Placeholder';">
                 <span>YouTube</span>
             </a>
             <a href="https://steamcommunity.com/id/Kazu-Hani/" target="_blank" rel="noopener noreferrer"
-               class="social-icon flex items-center justify-center w-full bg-slate-600 hover:bg-slate-700 text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="View Kazu Hani's Steam Profile">
+               class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="View Kazu Hani's Steam Profile"> <!-- Removed py-3 px-4 -->
                 <img src="Images/steam_logo.png" alt="Steam Logo" class="w-6 h-6 mr-3" onerror="this.onerror=null; this.src='https://placehold.co/24x24/1b2838/ffffff?text=S&font=roboto'; this.alt='Steam Placeholder';">
                 <span>Steam</span>
             </a>
             <a href="https://www.reddit.com/user/Korat24/" target="_blank" rel="noopener noreferrer"
-               class="social-icon flex items-center justify-center w-full bg-orange-500 hover:bg-orange-600 text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="View Kazu Hani's (Korat24) Reddit Profile">
+               class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="View Kazu Hani's (Korat24) Reddit Profile"> <!-- Removed py-3 px-4 -->
                 <img src="Images/reddit_logo.png" alt="Reddit Logo" class="w-6 h-6 mr-3" onerror="this.onerror=null; this.src='https://placehold.co/24x24/FF5700/ffffff?text=R&font=roboto'; this.alt='Reddit Placeholder';">
                 <span>Reddit</span>
             </a>
             <a href="https://myanimelist.net/animelist/Kazu_Hani" target="_blank" rel="noopener noreferrer"
-               class="social-icon flex items-center justify-center w-full bg-blue-700 hover:bg-blue-800 text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="View Kazu Hani's Anime List on MyAnimeList">
+               class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="View Kazu Hani's Anime List on MyAnimeList"> <!-- Removed py-3 px-4 -->
                 <!-- Using MyAnimeList_Logo.jpg -->
                 <img src="Images/MyAnimeList_Logo.jpg" alt="MyAnimeList Logo Icon" class="w-6 h-6 mr-3" onerror="this.onerror=null; this.src='https://placehold.co/24x24/2e51a2/ffffff?text=MAL&font=roboto'; this.alt='MyAnimeList Placeholder';">
                 <span>MyAnimeList</span>
             </a>
             <a href="https://character.ai/profile/Kazu_Hani" target="_blank" rel="noopener noreferrer"
-               class="social-icon flex items-center justify-center w-full bg-black hover:bg-gray-800 text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="Chat with Kazu Hani on Character.ai">
+               class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="Chat with Kazu Hani on Character.ai"> <!-- Removed py-3 px-4 -->
                 <img src="Images/CharacterAIlogo.png" alt="Character.ai Logo" class="w-6 h-6 mr-3" onerror="this.onerror=null; this.src='https://placehold.co/24x24/8B5CF6/ffffff?text=C.AI&font=roboto'; this.alt='Character.ai Placeholder';">
                 <span>Character.ai</span>
             </a>
@@ -198,12 +197,11 @@
             <!-- New Discord Button and Dropdown -->
             <div class="discord-container">
                 <button id="discordButton"
-                   class="social-icon flex items-center justify-center w-full text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll"
-                   aria-expanded="false" aria-controls="discordDropdownText" title="Get Kazu Hani's Discord username">
+                   class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll"  aria-expanded="false" aria-controls="discordDropdownText" title="Get Kazu Hani's Discord username"> <!-- Removed py-3 px-4 -->
                     <i class="fab fa-discord w-6 h-6 mr-3" aria-hidden="true"></i>
                     <span>Discord</span>
                 </button>
-                <div id="discordDropdownText" class="discord-dropdown-text text-center text-slate-300 text-sm" role="region" aria-labelledby="discordButton">
+                <div id="discordDropdownText" class="discord-dropdown-text text-center text-sm" role="region" aria-labelledby="discordButton">
                     add me kazu_hani
                 </div>
             </div>
@@ -217,53 +215,51 @@
             }
         </script>
 
-        <div class="mt-8 pt-6 border-t border-slate-600">
-            <h2 id="toc-music-playlist" class="toc-section-header text-xl font-semibold text-indigo-400 mb-4 text-center fade-in-on-scroll">My music playlist</h2>
-            <div class="playlist-container flex justify-center items-center mt-10 mb-6">
+        <div class="mt-6 pt-4 border-t"> <!-- Reduced mt-8 pt-6 to mt-6 pt-4 -->
+            <h2 id="toc-music-playlist" class="toc-section-header text-xl font-semibold mb-3 text-center fade-in-on-scroll">My music playlist</h2> <!-- Reduced mb-4 to mb-3 -->
+            <div class="playlist-container flex justify-center items-center mt-8 mb-4"> <!-- Reduced mt-10 mb-6 to mt-8 mb-4 -->
                 <a href="https://music.youtube.com/playlist?list=PLEWxJlvxPVrkYhMCA1IlYwDh5bg-jf39m&si=w-bZgfAEO1mV_faj"
                    target="_blank" rel="noopener noreferrer" class="relative group inline-block fade-in-on-scroll">
                     <i class="fas fa-arrow-down playlist-arrow" title="Listen to Kazu Hani's playlist on YouTube Music"></i>
                     <img src="Images/Sisu.jpg" alt="Sisu the Dragon"
-                         class="sisu-image w-56 h-56 rounded-full object-cover shadow-lg" loading="lazy">
+                         class="sisu-image w-56 h-56 object-cover fade-in-on-scroll" loading="lazy"> <!-- Ensure rounded-full is removed if it was here -->
                     <span class="party-text party-text-left">Party</span>
                     <span class="party-text party-text-right">Time</span>
                 </a>
             </div>
         </div>
 
-        <div class="mt-8 pt-6 border-t border-slate-700">
-            <h2 id="toc-website-code" class="toc-section-header text-xl font-semibold text-indigo-400 mb-4 fade-in-on-scroll">Code used for this website</h2>
+        <div class="mt-6 pt-4 border-t"> <!-- Reduced mt-8 pt-6 to mt-6 pt-4 -->
+            <h2 id="toc-website-code" class="toc-section-header text-xl font-semibold mb-3 fade-in-on-scroll">Code used for this website</h2> <!-- Reduced mb-4 to mb-3 -->
             <a href="https://github.com/KazuHani/Kazu-Hub" target="_blank" rel="noopener noreferrer"
-               class="social-icon flex items-center justify-center w-full bg-gray-700 hover:bg-gray-800 text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="View the source code for Kazu Hub on GitHub">
+               class="social-icon flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="View the source code for Kazu Hub on GitHub"> <!-- Removed py-3 px-4 -->
                 <svg class="w-6 h-6 mr-3" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.419 2.865 8.166 6.839 9.489.5.092.682-.217.682-.483 0-.237-.009-.868-.013-1.703-2.782.602-3.369-1.34-3.369-1.34-.455-1.158-1.11-1.468-1.11-1.468-.908-.62.069-.608.069-.608 1.004.071 1.532 1.03 1.532 1.03.891 1.529 2.341 1.089 2.91.833.091-.647.349-1.086.635-1.337-2.22-.251-4.555-1.111-4.555-4.943 0-1.091.39-1.984 1.029-2.682-.103-.252-.446-1.27.098-2.646 0 0 .84-.269 2.75 1.025A9.547 9.547 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.748-1.025 2.748-1.025.546 1.376.203 2.394.1 2.646.64.698 1.027 1.591 1.027 2.682 0 3.842-2.338 4.687-4.565 4.935.358.307.679.917.679 1.852 0 1.336-.012 2.415-.012 2.741 0 .269.18.579.688.481A10.007 10.007 0 0022 12c0-5.523-4.477-10-10-10z" clip-rule="evenodd"/>
                 </svg>
                 <span>View on GitHub</span>
             </a>
 
-            <h2 id="toc-my-stories" class="toc-section-header text-xl font-semibold text-indigo-400 mt-6 mb-3 fade-in-on-scroll">My Stories</h2>
+            <h2 id="toc-my-stories" class="toc-section-header text-xl font-semibold mt-4 mb-2 fade-in-on-scroll">My Stories</h2> <!-- Reduced mt-6 mb-3 to mt-4 mb-2 -->
             <button id="backstoryTrigger"
-                    class="backstory-trigger-btn w-full flex items-center justify-center text-white font-semibold py-3 px-4 rounded-lg shadow-md mb-2 fade-in-on-scroll" title="Read Kazu's backstory">
+                    class="backstory-trigger-btn w-full flex items-center justify-center font-semibold mb-2 fade-in-on-scroll" title="Read Kazu's backstory"> <!-- Removed py-3 px-4 -->
                 Kazu's backstory
             </button>
 
-            <div class="mt-4 space-y-2">
+            <div class="mt-3 space-y-2"> <!-- Reduced mt-4 to mt-3 -->
                 <a href="https://docs.google.com/document/d/e/2PACX-1vSYd2SLW1AjBMfKZj0DC-ZMMDWYSeDYPykYspUuKiUDFkVE3dfnfR9Hhw6XBhwYezjVZCnSMTflJVuW/pub" target="_blank" rel="noopener noreferrer"
-                   class="social-icon story-button-legend flex items-center justify-center w-full text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="Read Kazu's story: The Legend That Bleeds"
-                   style="background-image: url('Images/blood.png'); background-size: cover; background-position: center; background-repeat: no-repeat;">
-                    <span style="text-shadow: 1px 1px 3px rgba(0,0,0,0.7);">The Legend That Bleeds</span>
+                   class="social-icon story-button-legend flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="Read Kazu's story: The Legend That Bleeds"> <!-- Removed py-3 px-4 -->
+                    <span>The Legend That Bleeds</span>
                 </a>
                 <a href="https://docs.google.com/document/d/e/2PACX-1vS0rxLFpamMCc8gcZNW0NZ9NTNwmg24VTAWUC2zQ6IRoCdTrtBa_juI9_ta7IOW1r-prRyiqDkdjQ65/pub" target="_blank" rel="noopener noreferrer"
-                   class="social-icon story-button-naga flex items-center justify-center w-full text-white font-semibold py-3 px-4 rounded-lg shadow-md fade-in-on-scroll" title="Read Kazu's story: The Naga And Human Kind"
-                   style="background-image: url('Images/arctic.jpg'); background-size: cover; background-position: center; background-repeat: no-repeat;">
-                    <span style="text-shadow: 1px 1px 3px rgba(0,0,0,0.7);">The Naga And Human Kind</span>
+                   class="social-icon story-button-naga flex items-center justify-center w-full font-semibold fade-in-on-scroll" title="Read Kazu's story: The Naga And Human Kind"> <!-- Removed py-3 px-4 -->
+                    <span>The Naga And Human Kind</span>
                 </a>
             </div>
         </div> <!-- End of My Stories Section -->
 
-        <div class="mt-8 pt-6 border-t border-slate-700">
-            <h2 id="toc-where-i-am" class="toc-section-header text-xl font-semibold text-indigo-400 mb-4 fade-in-on-scroll">Where I am</h2>
-            <div class="rounded-lg shadow-md overflow-hidden fade-in-on-scroll"> <!-- Wrapper for iframe styling -->
+        <div class="mt-6 pt-4 border-t"> <!-- Reduced mt-8 pt-6 to mt-6 pt-4 -->
+            <h2 id="toc-where-i-am" class="toc-section-header text-xl font-semibold mb-3 fade-in-on-scroll">Where I am</h2> <!-- Reduced mb-4 to mb-3 -->
+            <div class="overflow-hidden fade-in-on-scroll"> <!-- Wrapper for iframe styling -->
                 <iframe
                     src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5021369.004948138!2d-4.208000000000001!3d54.268000000000005!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x25a3b1142c791a9%3A0xc4f8a0433288257a!2sUnited%20Kingdom!5e0!3m2!1sen!2sus!4v1716467858509!5m2!1sen!2sus"
                     class="w-full h-80 md:h-96" <!-- Responsive height, full width -->
@@ -276,8 +272,8 @@
             </div>
         </div> <!-- End of Where I am Section -->
 
-        <footer class="mt-10 pt-6 border-t border-slate-600 fade-in-on-scroll">
-            <p class="text-center text-sm text-slate-400">
+        <footer class="mt-8 pt-4 border-t fade-in-on-scroll"> <!-- Reduced mt-10 pt-6 to mt-8 pt-4 -->
+            <p class="text-center text-sm">
                 Coded by Google Gemini
             </p>
         </footer>
@@ -1000,7 +996,9 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
                     const link = document.createElement('a');
                     link.href = `#${id}`;
                     link.textContent = title;
-                    link.classList.add('text-slate-300', 'hover:text-white', 'hover:bg-slate-700', 'block', 'py-0.5', 'px-1.5', 'rounded', 'text-sm', 'transition-colors', 'duration-150');
+                    // Adjusted classes for Win95 style: block for layout, py-0.5/px-1.5 for padding, text-sm for size.
+                    // Removed: text-slate-300, hover:text-white, hover:bg-slate-700, rounded, transition-colors, duration-150
+                    link.classList.add('block', 'py-0.5', 'px-1.5', 'text-sm');
                     link.dataset.tocLinkFor = id;
 
                     link.addEventListener('click', function(e) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -15,7 +15,9 @@
         }
 
         body {
-            font-family: 'Roboto', 'Inter', sans-serif;
+            font-family: Arial, sans-serif;
+            background-color: #008080;
+            color: #000000;
             margin: 0; /* Basic reset */
             transition: background-image 0.5s ease-in-out, background-color 0.5s ease-in-out, color 0.5s ease-in-out; /* Smooth transition for background and text color changes */
             position: relative; /* Ensure body is a stacking context for its children */
@@ -25,25 +27,69 @@
         }
         /* Google Fonts 'Roboto' and 'Inter' are linked in the <head> */
         /* Styling for social icons and similar buttons. Increased specificity for transition. */
-        a.social-icon, button.social-icon {
-            transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+        button,
+        a.social-icon,
+        button.social-icon,
+        .info-button,
+        button.backstory-trigger-btn {
+            background-color: #C0C0C0;
+            color: #000000;
+            border: 2px solid;
+            border-top-color: #FFFFFF;
+            border-left-color: #FFFFFF;
+            border-bottom-color: #808080;
+            border-right-color: #808080;
+            box-shadow: none;
+            border-radius: 0;
+            padding: 5px 10px; /* Basic padding for buttons */
             font-size: 0.9rem;
             position: relative;
-            /* overflow: hidden; /* Removed to allow hover effects like scale and shadow to be fully visible */
             z-index: 1;
+            text-decoration: none; /* Remove underline from <a> tags styled as buttons */
+            transition: border-color 0.1s ease-in-out; /* For hover effect */
         }
-        .social-icon span { /* Target the text span directly for z-index if needed */
-            position: relative;
-            z-index: 2;
+
+        /* General link styling */
+        a {
+            color: #0000FF;
+            text-decoration: underline;
         }
+        a:hover {
+            /* Consider a slightly different shade of blue or other Win95 link hover style if desired */
+        }
+
         .social-icon img, .social-icon svg { /* Ensure icons are also above overlay */
             position: relative;
             z-index: 2;
+            filter: none; /* Attempt to reset any color changes on icons */
         }
 
-        a.social-icon:hover, button.social-icon:hover { /* Matched specificity for hover */
-            transform: translateY(-5px) scale(1.03);
-            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+        button, /* Ensure buttons (which might be <a>) don't get underlined */
+        a.social-icon,
+        button.social-icon,
+        .info-button,
+        button.backstory-trigger-btn {
+            text-decoration: none !important; /* Override general <a> underline for button-styled links */
+        }
+
+
+        button:hover,
+        a.social-icon:hover,
+        button.social-icon:hover,
+        .info-button:hover,
+        button.backstory-trigger-btn:hover,
+        button:active,
+        a.social-icon:active,
+        button.social-icon:active,
+        .info-button:active,
+        button.backstory-trigger-btn:active {
+            transform: none;
+            box-shadow: none;
+            border-top-color: #808080;
+            border-left-color: #808080;
+            border-bottom-color: #FFFFFF;
+            border-right-color: #FFFFFF;
+            background-image: none; /* Ensure no gradient/image on hover */
         }
 
         .container {
@@ -51,7 +97,14 @@
             max-width: 500px;
             padding: 1rem;
             animation: zoomInEffect 0.7s ease-out forwards;
-            background-color: rgba(30, 41, 59, 0.9);
+            background-color: #C0C0C0;
+            border: 2px solid;
+            border-top-color: #FFFFFF;
+            border-left-color: #FFFFFF;
+            border-bottom-color: #808080;
+            border-right-color: #808080;
+            box-shadow: none;
+            border-radius: 0;
             position: relative; /* Establish stacking context */
             z-index: 2;         /* Ensure container is above bouncing images */
             /* margin-top: 4rem; /* Removed as icons are now in normal flow */
@@ -59,22 +112,20 @@
         @media (min-width: 640px) { /* sm breakpoint in Tailwind */
             .container {
                 padding: 2rem;
+                /* Ensure border-radius is also reset here if it was previously set for larger screens */
+                border-radius: 0;
             }
         }
-        .info-button {
-            transition: background-color 0.3s ease-in-out, transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
-        }
-        .info-button:hover {
-            transform: translateY(-5px) scale(1.1);
-            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
-        }
+        /* .info-button specific overrides if any (already covered by general button styling) */
 
         @keyframes continuousSpin {
             from { transform: rotate(0deg); }
             to { transform: rotate(360deg); }
         }
         .profile-picture {
-            transition: transform 0.5s ease-in-out;
+            transition: transform 0.5s ease-in-out; /* Keep existing transition for now */
+            border: 1px solid #808080; /* Simple gray border */
+            border-radius: 0; /* Ensure no rounded corners if previously set by Tailwind */
         }
         /* .profile-picture:hover {
             animation: continuousSpin 2s linear infinite;
@@ -86,26 +137,33 @@
         }
         #birthdayCountdown {
             font-size: 1rem;
-            color: #cbd5e1;
+            /* color: #cbd5e1; */ /* Replaced by body color or container color */
             margin-bottom: 0.5rem;
         }
         #ageDisplay {
             font-size: 1rem;
-            color: #cbd5e1;
+            /* color: #cbd5e1; */ /* Replaced by body color or container color */
             margin-bottom: 1.5rem;
         }
-        .bio-text { font-size: 0.95rem; }
-        .highlight-text { color: #818cf8; font-weight: 600; }
+        .bio-text { font-size: 0.95rem; /* Color will be inherited */ }
+        .highlight-text { color: #000000; font-weight: bold; /* Black and bold for highlight */ }
         .profile-image-wrapper { display: inline-block; text-align: center; }
         #dragonText {
-            max-height: 0; opacity: 0; overflow: hidden; color: #f87171;
+            max-height: 0; opacity: 0; overflow: hidden; color: #000000; /* Black text */
             font-weight: bold; font-size: 1.5rem; white-space: nowrap;
-            background-color: rgba(30, 41, 59, 0.85); border-radius: 0.375rem;
-            padding: 0 12px; margin-top: 0; box-sizing: border-box;
+            background-color: #C0C0C0;
+            border-radius: 0; /* Silver background, no radius */
+            border: 2px solid;
+            border-top-color: #FFFFFF;
+            border-left-color: #FFFFFF;
+            border-bottom-color: #808080;
+            border-right-color: #808080;
+            padding: 5px 10px; /* Consistent padding */
+            margin-top: 0; box-sizing: border-box;
             transition: max-height 0.4s ease-out, opacity 0.4s ease-out, margin-top 0.4s ease-out, padding-top 0.4s ease-out, padding-bottom 0.4s ease-out;
         }
         #dragonText.visible {
-            max-height: 70px; /* Ensure this is enough for the text */ opacity: 1; margin-top: 10px; padding-top: 6px; padding-bottom: 6px;
+            max-height: 70px; /* Ensure this is enough for the text */ opacity: 1; margin-top: 10px; padding-top: 6px; padding-bottom: 6px; /* Keep padding for visibility transition */
         }
         @keyframes flameAnimation {
             0%, 100% { background-position: 0% 50%; }
@@ -118,42 +176,35 @@
             animation: flameAnimation 15s ease infinite !important;
         }
         .story-button-legend, .story-button-naga {
-            background-size: cover; background-position: center center; background-repeat: no-repeat; color: white;
-            
+            /* background-size: cover; background-position: center center; background-repeat: no-repeat; */ /* Removed */
+            /* color: white; */ /* Handled by general button */
+            background-image: none !important; /* Ensure no background image */
         }
         .story-button-legend::before, .story-button-naga::before {
-            content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0;
-            background-color: rgba(0, 0, 0, 0.4); border-radius: inherit;
-            z-index: 1; transition: background-color 0.3s ease;
+            content: none; /* Remove overlay */
         }
-        .story-button-legend:hover::before, .story-button-naga:hover::before {
-            background-color: rgba(0, 0, 0, 0.6);
-        }
-        .story-button-legend { background-image: url('/images/blood.png'); }
-        .story-button-naga { background-image: url('/images/arctic.jpg'); }
+        /* .story-button-legend:hover::before, .story-button-naga:hover::before { Removed } */
+        /* .story-button-legend { background-image: url('/images/blood.png'); } */ /* Removed */
+        /* .story-button-naga { background-image: url('/images/arctic.jpg'); } */ /* Removed */
 
-        /* Increased specificity for transition for the backstory trigger button */
-        button.backstory-trigger-btn {
-            background-color: #4a5568;
-            /* Tailwind classes now handle: color, padding, border-radius, font-weight, margin-bottom */
-            cursor: pointer;
-            transition: background-color 0.2s ease, transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
-            border: none;
-            font-size: 1rem; /* Retaining specific font size for this button */
-        }
-        /* Discord Button Specific Styles */
+        /* backstory-trigger-btn is covered by general button styling */
+        /* Discord Button Specific Styles - override general button styles */
         #discordButton {
-            background-color: #5865F2; /* Discord blurple */
+            background-color: #C0C0C0 !important; /* Override specific Discord blurple */
+            color: #000000 !important;
         }
-        #discordButton:hover {
-            background-color: #4752C4; /* Darker blurple */
+        #discordButton:hover, #discordButton:active {
+            background-color: #C0C0C0 !important; /* Consistent Win95 feel */
+            border-top-color: #808080 !important;
+            border-left-color: #808080 !important;
+            border-bottom-color: #FFFFFF !important;
+            border-right-color: #FFFFFF !important;
         }
-        /* Hover effect for backstory-trigger-btn, matched specificity */
-        button.backstory-trigger-btn:hover {
-            background-color: #2d3748;
-            transform: translateY(-5px) scale(1.03);
-            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+        /* Ensure Discord icon itself is not colored by its original SVG fill if possible, or use a monochrome version */
+        #discordButton .fab.fa-discord {
+            color: #000000 !important; /* Make Discord icon black */
         }
+
 
         .discord-dropdown-text {
             max-height: 0;
@@ -163,8 +214,11 @@
             padding-top: 0;
             padding-bottom: 0;
             margin-top: 0; /* Start with no margin, will be added when visible */
-            background-color: rgba(55, 65, 81, 0.85); /* e.g., slate-700 with opacity */
-            border-radius: 0 0 0.375rem 0.375rem; /* Tailwind's rounded-md for bottom */
+            background-color: #FFFFFF !important; /* White background for dropdown */
+            border: 2px inset #808080 !important; /* Inset border */
+            border-radius: 0 !important; /* No rounded corners */
+            color: #000000 !important; /* Black text */
+            padding: 5px; /* Add some padding */
         }
         .discord-dropdown-text.visible {
             max-height: 70px; /* Adjust if text is longer or needs more space */
@@ -229,86 +283,97 @@
             max-height: 100vh;/* Ensure it doesn't exceed viewport height */
             overflow-y: auto; /* Allow scrolling for content longer than screen */
             position: relative; text-align: left;
-            color: #e2e8f0;
+            color: #000000; /* Black text */
             font-size: 1.05rem;
             line-height: 1.7;
-            transform: scale(0.95);
-            transition: transform 0.3s ease-in-out;
+            transform: scale(1); /* No scale effect */
+            transition: none; /* No transition */
             box-sizing: border-box; /* Include padding and border in the element's total width and height */
+            border: 2px solid; /* Standard Win95 border */
+            border-top-color: #FFFFFF;
+            border-left-color: #FFFFFF;
+            border-bottom-color: #808080;
+            border-right-color: #808080;
+            background-color: #C0C0C0; /* Silver background */
         }
         #backstoryModal.visible #backstoryModalContent { transform: scale(1); }
         .close-modal-button {
-            position: absolute; top: 10px; right: 15px;
-            /* --- Repositioned to bottom center --- */
-            position: fixed; /* Changed from absolute to ensure viewport-relative positioning */
-            top: auto;
-            right: auto; /* Remove right positioning */
-            bottom: 20px; /* Distance from the bottom */
-            left: 50%;    /* Center horizontally */
-            transform: translateX(-50%); /* Base transform for centering */
-
-            /* --- New Circular Button Styles --- */
-            width: 60px; /* Define width for the circle */
-            height: 60px; /* Define height for the circle */
-            border-radius: 50%; /* Make it circular */
-            background-color: #334155; /* slate-700 for dark theme */
-            color: #cbd5e1; /* slate-300 for 'X' in dark theme */
-            font-size: 2.8rem; /* Adjusted 'X' size to fit circle */
-            display: flex;
-            align-items: center;
-            justify-content: center;
-
-            cursor: pointer; background: none; border: none;
-            line-height: 1; /* Important for flex centering */
-            padding: 0; /* Remove previous padding, flex handles centering */
-            z-index: 1001; /* Above modal backdrop (z-index: 1000) */
-            transition: background-color 0.3s ease, color 0.3s ease, transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+            /* Already covered by general button styling, but ensure specific overrides if needed */
+            background-color: #C0C0C0 !important;
+            color: #000000 !important;
+            border: 2px solid;
+            border-top-color: #FFFFFF !important;
+            border-left-color: #FFFFFF !important;
+            border-bottom-color: #808080 !important;
+            border-right-color: #808080 !important;
+            box-shadow: none !important;
+            border-radius: 0 !important;
+            width: auto; /* Auto width based on content */
+            height: auto; /* Auto height */
+            font-size: 1rem; /* Standard button font size */
+            padding: 5px 10px; /* Standard button padding */
+            /* Resetting flex properties if they conflict */
+            display: inline-block;
+            text-align: center;
+            line-height: normal;
+            /* Ensure transform is reset from previous fixed positioning */
+            transform: none;
+            position: absolute; /* Or static/relative as needed for flow */
+            top: 10px;
+            right: 10px;
+            bottom: auto;
+            left: auto;
         }
-        .close-modal-button:hover {
-            background-color: #475569; /* slate-600 for dark theme hover */
-            color: #e2e8f0; /* slate-200 for 'X' on hover */
-            transform: translateX(-50%) translateY(-5px) scale(1.03); /* Combine centering with hover effects */
-            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25); /* Slightly more pronounced shadow for dark theme */
+        .close-modal-button:hover, .close-modal-button:active {
+            transform: none !important;
+            box-shadow: none !important;
+            border-top-color: #808080 !important;
+            border-left-color: #808080 !important;
+            border-bottom-color: #FFFFFF !important;
+            border-right-color: #FFFFFF !important;
+            background-image: none !important;
         }
-        /* Make it even larger on mobile */
-        @media (max-width: 767px) {
+
+        /* Make it even larger on mobile - this might be removed if not fitting Win95 style */
+        /* @media (max-width: 767px) {
             .close-modal-button {
-                width: 75px; /* Increased width for mobile */
-                height: 75px; /* Increased height for mobile */
-                font-size: 3.5rem; /* Increased 'X' size for larger mobile button */
-                bottom: 20px; /* More space from the bottom edge on mobile */
+                width: 75px;
+                height: 75px;
+                font-size: 3.5rem;
+                bottom: 20px;
             }
-        }
+        } */
         #backstoryModalContent p { margin-bottom: 1rem; }
         #backstoryModalContent p:last-child { margin-bottom: 0; }
 
         /* Sisu Image and Party Time Text Styles */
         .sisu-image {
-            transform: rotate(0deg); /* Initial upright state */
-            /* Transition for returning to upright and for box-shadow changes */
-            transition: transform 0.7s ease-out, box-shadow 0.3s ease-in-out;
-            backface-visibility: hidden; /* May help stabilize transform rendering and transitions */
-            /* Ensure no animation is running by default, which might help clarify state for transitions */
+            transform: none;
+            transition: none;
+            backface-visibility: hidden;
             animation: none;
-            /* Tailwind classes used: w-56 h-56 rounded-full object-cover shadow-lg */
+            border: 2px solid;
+            border-top-color: #FFFFFF;
+            border-left-color: #FFFFFF;
+            border-bottom-color: #808080;
+            border-right-color: #808080;
+            border-radius: 0; /* Override rounded-full from HTML if not removed */
+            box-shadow: none;
         }
 
         .group:hover .sisu-image {
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25); /* Enhanced shadow */
-            /* The 'animation' property takes precedence over the 'transform' transition during hover.
-               Upon hover exit, the base 'transition' on '.sisu-image' for 'transform'
-               will ensure a smooth return to the upright position. */
+            box-shadow: none;
+            /* No specific hover transform or animation */
         }
-
-        .party-text {
+        .party-text { /* party-text color already changed to black */
             position: absolute;
             top: 50%;
             font-size: 2.25rem; /* text-4xl */
             font-weight: bold; /* font-bold */
-            color: #fca5a5; /* Tailwind red-300 */
-            text-shadow: 1px 1px 2px rgba(0,0,0,0.7);
+            color: #000000; /* Black text */
+            text-shadow: none; /* Remove text shadow */
             opacity: 0;
-            transition: opacity 0.3s ease-out, transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            transition: opacity 0.3s ease-out, transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94); /* Keep transition for now */
             pointer-events: none; /* So text doesn't interfere with image hover */
             white-space: nowrap;
             z-index: 10;
@@ -338,7 +403,8 @@
             left: 50%;
             transform: translateX(-50%); /* Center horizontally */
             font-size: 1.8rem; /* Size of the arrow */
-            color: #818cf8; /* Tailwind indigo-400, matching other highlights */
+            color: #0000FF; /* Standard link blue */
+            text-decoration: none; /* Arrows usually aren't underlined */
             z-index: 5; /* Below party text (z-index: 10), above default image flow */
         }
 
@@ -349,201 +415,76 @@
             }
         }
 
-        .bouncing-image { /* Changed from #bouncingLogo to a class */
-            position: absolute;
-            width: 250px; /* Adjust size as needed - Made them larger */
-            height: auto;  /* Maintain aspect ratio */
-            z-index: 1; /* Lower z-index to be in the background */
-            opacity: 0; /* Start fully transparent for fade-in */
-            visibility: hidden; /* Initially hide to prevent alt text flash */
-            transition: opacity 0.5s ease-in-out; /* Transition for smooth fade-in */
-            transform: translateZ(0); /* Attempt to promote to its own rendering layer */
+        .bouncing-image {
+            display: none !important;
+        }
+        .bouncing-snowflake {
+            display: none !important;
         }
 
         /* --- Scroll Rocket (Replaces Back to Top Button) --- */
-        /*
-            JS Interaction Plan:
-            1. On scroll (e.g., > 800px or 2 viewports): Add '.rocket-visible' to #backToTopBtn.
-            2. On #backToTopBtn click:
-               a. Add '.rocket-igniting'.
-               b. Play sound (optional).
-               c. setTimeout for var(--rocket-ignition-duration):
-                  i. Remove '.rocket-igniting', add '.rocket-launching'.
-                  ii. Start smooth scroll to top (e.g., window.scrollTo({top: 0, behavior: 'smooth'})).
-            3. On scroll completion (page at top):
-               a. Remove '.rocket-launching', add '.rocket-departing'.
-               b. setTimeout for var(--rocket-departure-duration):
-                  i. Remove '.rocket-departing'. (Rocket is now off-screen and hidden).
-            4. If user scrolls down again while rocket is visible (but not launching/departing), it remains.
-               If user scrolls back to top manually, JS should remove '.rocket-visible'.
-        */
         #backToTopBtn {
             position: fixed;
-            bottom: var(--rocket-bottom-offset);
-            right: var(--rocket-side-offset);
-            /* For bottom-left: left: var(--rocket-side-offset); right: auto; transform: var(--rocket-initial-transform-out-left, translateX(-120%)); */
-            width: var(--rocket-size);
-            height: var(--rocket-size);
-            background-color: var(--rocket-color-idle);
-            color: white;
-            border: none;
-            /* A simple rocket-like shape. An SVG would be more precise. */
-            border-radius: 40% 40% 20% 20% / 60% 60% 40% 40%;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+            bottom: 20px; /* Default offset */
+            right: 20px;  /* Default offset */
+            width: 50px;  /* Default size */
+            height: 50px; /* Default size */
+            background-color: #C0C0C0; /* Silver */
+            color: #000000; /* Black icon/text */
+            border: 2px solid;
+            border-top-color: #FFFFFF;
+            border-left-color: #FFFFFF;
+            border-bottom-color: #808080;
+            border-right-color: #808080;
+            box-shadow: none;
+            border-radius: 0;
             cursor: pointer;
-            z-index: 999; /* Ensure it's above most content */
-            /* --- TEMPORARY CHANGE: Make rocket visible by default for styling/testing --- */
-            opacity: 1;
+            z-index: 999;
+            opacity: 1; /* Always visible for now, JS can hide/show */
             visibility: visible;
-            transform: translateX(0); /* Position it in view */
-            /* Start bobbing animation immediately if always visible */
-            animation: rocketBobbing var(--rocket-bobbing-duration) infinite ease-in-out;
-            /* --- END TEMPORARY CHANGE --- */
+            transform: none; /* No slide-in/out transform by default */
+            animation: none; /* No bobbing or other animations */
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 0; /* Effectively hide direct text content, icon is in ::before */
-            transition: /* opacity var(--rocket-slide-in-duration) ease-out, */ /* Transitions for initial appearance handled by direct visibility now */
-                        /* visibility var(--rocket-slide-in-duration) ease-out, */
-                        transform var(--rocket-slide-in-duration) ease-out,
-                        background-color 0.3s ease,
-                        box-shadow 0.3s ease;
+            font-size: 1.5rem; /* Size for Font Awesome icon */
+            transition: border-color 0.1s ease-in-out; /* For hover effect */
         }
 
-        /* Rocket icon placeholder - ideally use an SVG */
+        #backToTopBtn:hover, #backToTopBtn:active {
+            border-top-color: #808080;
+            border-left-color: #808080;
+            border-bottom-color: #FFFFFF;
+            border-right-color: #FFFFFF;
+            background-image: none;
+            transform: none; /* No hover transform */
+            box-shadow: none;
+        }
+
+        /* Original rocket icon was in ::before, let's ensure it's still there or use direct icon */
+        /* If using Font Awesome directly in the button HTML, this ::before might not be needed or can be simplified */
         #backToTopBtn::before {
-            content: '🚀'; /* Placeholder rocket emoji */
-            display: inline-block;
-            line-height: 1;
-            font-size: calc(var(--rocket-size) * 0.5); /* Actual icon size */
+            /* content: '🚀'; /* Using Font Awesome icon directly in HTML now */
+            /* display: inline-block; */
+            /* line-height: 1; */
+            /* font-size: calc(var(--rocket-size) * 0.5); */
+            /* Ensure icon color is black */
+            color: #000000;
         }
 
-        /* Subtle exhaust/particle effect for idle state */
-        #backToTopBtn::after {
-            content: '';
-            position: absolute;
-            bottom: -6px; /* Position below the rocket base */
-            left: 50%;
-            width: calc(var(--rocket-size) * 0.25);
-            height: calc(var(--rocket-size) * 0.25);
-            background: radial-gradient(circle, var(--rocket-flame-color-outer) 0%, transparent 70%);
-            border-radius: 50%;
-            opacity: 0; /* Hidden by default, shown with .rocket-visible */
-            transform: translateX(-50%);
-            transition: opacity 0.3s ease-out, width 0.3s ease, height 0.3s ease, bottom 0.3s ease, background 0.3s ease;
+        #backToTopBtn::after { /* Flame/exhaust effects */
+            display: none !important;
         }
 
-        #backToTopBtn.rocket-visible {
-            opacity: 1;
-            visibility: visible;
-            transform: translateX(0); /* Slide in - This class will still be used by JS for the slide-in effect if you revert the temporary change */
-            /* Bobbing animation is now on the base style for the temporary always-visible state.
-               If you revert, you might want to add the animation delay back here:
-               animation: rocketBobbing var(--rocket-bobbing-duration) infinite ease-in-out var(--rocket-slide-in-duration); */
-        }
-
-        #backToTopBtn.rocket-visible::after, #backToTopBtn::after { /* Apply to base style as well for always-visible */
-            opacity: 0.6;
-            animation: subtleSparks 1.5s infinite ease-in-out;
-        }
-
-        #backToTopBtn:hover {
-            /* Only apply hover effects if rocket is visible and not in a launching/departing state */
-            /* JS might need to add a class like '.can-hover' or this can be handled by specificity */
-        }
-        #backToTopBtn.rocket-visible:hover {
-            background-color: var(--rocket-color-hover);
-            /* Tilt and scale, ensure translateX(0) is maintained from .rocket-visible */
-            transform: translateX(0) rotate(-10deg) scale(1.1);
-            box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
-        }
-
-        #backToTopBtn.rocket-visible:hover::after {
-            bottom: calc(var(--rocket-size) * -0.2); /* Further down */
-            width: calc(var(--rocket-size) * 0.35);
-            height: calc(var(--rocket-size) * 0.35);
-            background: radial-gradient(circle, var(--rocket-flame-color-inner) 20%, var(--rocket-flame-color-outer) 50%, transparent 80%);
-            opacity: 1;
-            animation: intenseSparks 0.5s infinite linear; /* More rapid sparks */
-        }
-
-        /* Ignition State (briefly on click) */
-        #backToTopBtn.rocket-igniting {
-            animation: rocketShake var(--rocket-ignition-duration) ease-out;
-        }
-        #backToTopBtn.rocket-igniting::after {
-            bottom: calc(var(--rocket-size) * -0.3);
-            width: calc(var(--rocket-size) * 0.4);
-            height: calc(var(--rocket-size) * 0.7); /* Elongated flame */
-            background: linear-gradient(to top, var(--rocket-flame-color-inner), var(--rocket-flame-color-outer), transparent 70%);
-            border-radius: 50% 50% 10% 10% / 80% 80% 20% 20%; /* Flame shape */
-            opacity: 1;
-            animation: ignitionFlameBurst var(--rocket-ignition-duration) ease-out forwards;
-        }
-
-        /* Launching State (during page scroll) */
-        #backToTopBtn.rocket-launching::after {
-            bottom: calc(var(--rocket-size) * -0.3);
-            width: calc(var(--rocket-size) * 0.4);
-            height: calc(var(--rocket-size) * 0.7);
-            background: linear-gradient(to top, var(--rocket-flame-color-inner), var(--rocket-flame-color-outer), transparent 70%);
-            border-radius: 50% 50% 10% 10% / 80% 80% 20% 20%;
-            opacity: 1;
-            animation: sustainedFlame 0.3s infinite alternate ease-in-out;
-        }
-
-        /* Departing State (flies off screen) */
-        #backToTopBtn.rocket-departing {
-            /* The main transform is handled by rocketFlyOff animation */
-            animation: rocketFlyOff var(--rocket-departure-duration) ease-in forwards;
-        }
-        #backToTopBtn.rocket-departing::after {
-            animation: flameFadeOut var(--rocket-departure-duration) ease-in forwards;
-        }
-
-        @keyframes rocketBobbing {
-            0%, 100% { transform: translateY(0); } /* Base transform from .rocket-visible is translateX(0) */
-            50% { transform: translateY(-5px); }
-        }
-
-        @keyframes subtleSparks {
-            0%, 100% { opacity: 0.4; transform: translateX(-50%) scale(0.8); }
-            50% { opacity: 0.7; transform: translateX(-50%) scale(1); }
-        }
-
-        @keyframes intenseSparks {
-            0%   { transform: translateX(-50%) scale(1) translateY(0); opacity: 1; }
-            50%  { transform: translateX(-50%) scale(1.2) translateY(2px); opacity: 0.7; }
-            100% { transform: translateX(-50%) scale(1) translateY(0); opacity: 1; }
-        }
-
-        @keyframes rocketShake { /* Applied to the rocket itself for a launch shudder */
-            0%, 100% { transform: translateX(0) rotate(0); }
-            20% { transform: translateX(-2px) translateY(1px) rotate(-2deg); }
-            40% { transform: translateX(2px) translateY(-1px) rotate(2deg); }
-            60% { transform: translateX(-1px) translateY(1px) rotate(-1deg); }
-            80% { transform: translateX(1px) translateY(-1px) rotate(1deg); }
-        }
-
-        @keyframes ignitionFlameBurst {
-            from { transform: translateX(-50%) scaleY(0.5); opacity: 0.7; }
-            to   { transform: translateX(-50%) scaleY(1); opacity: 1; }
-        }
-
-        @keyframes sustainedFlame {
-            from { transform: translateX(-50%) scaleY(1) scaleX(1); opacity: 1; }
-            to   { transform: translateX(-50%) scaleY(0.85) scaleX(1.1); opacity: 0.9; }
-        }
-
-        @keyframes rocketFlyOff {
-            0%   { transform: translateX(0) translateY(0) rotate(-10deg); opacity: 1; } /* Assumes it might be tilted from hover/click */
-            100% { transform: translateX(0) translateY(-150vh) rotate(-45deg); opacity: 0; } /* Fly far off screen */
-        }
-
-        @keyframes flameFadeOut {
-            from { opacity: 1; transform: translateX(-50%) scaleY(1); }
-            to   { opacity: 0; transform: translateX(-50%) scaleY(0.2); }
-        }
+        /* Remove all animation keyframes related to the rocket */
+        @keyframes rocketBobbing {}
+        @keyframes subtleSparks {}
+        @keyframes intenseSparks {}
+        @keyframes rocketShake {}
+        @keyframes ignitionFlameBurst {}
+        @keyframes sustainedFlame {}
+        @keyframes rocketFlyOff {}
+        @keyframes flameFadeOut {}
 
 
         /* Fade-in on Scroll Effect */
@@ -578,90 +519,81 @@
 
         #moonIcon {
             /* top, left, transform removed */
-            color: #e2e8f0; /* Tailwind slate-200, a soft white/grey */
+            color: #000000; /* Black icon */
         }
         #sunIcon {
             /* top, left, transform removed */
-            color: #facc15; /* Tailwind yellow-400, a bright sun color */
+            color: #000000; /* Black icon (or consider yellow if it looks ok on teal) */
         }
 
-        /* Screen Edge Glow */
+        /* Screen Edge Glow - REMOVED */
         body::before {
-            content: '';
-            position: absolute; /* Changed from fixed to scroll with the page */
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 1px; /* Further reduced thickness for the line/glow origin at the top */
-            pointer-events: none; /* Allows interaction with elements underneath */
-            z-index: 1002; /* Above modal (1000) and close button (1001) */
-            /* Transition for background (the line color) and box-shadow (the glow) */
-            transition: background-color 0.7s ease-in-out, box-shadow 0.7s ease-in-out;
+            display: none !important;
+        }
+        body.day-glow-active::before, body.night-glow-active::before {
+            display: none !important;
         }
 
-        body.day-glow-active::before {
-            /* background-color removed to have no solid line for daytime */
-            box-shadow:
-                /* Glows emanate from the top edge (0px y-offset) */
-                0 0 30px 8px rgba(255, 255, 0, 0.95),  /* Bright Yellow Glow, slightly less spread/blur */
-                0 0 60px 12px rgba(255, 100, 0, 0.85); /* Wider Vibrant Orange Glow, slightly less spread/blur */
-        }
-
-        body.night-glow-active::before {
-            background-color: rgba(0, 0, 0, 1); /* Black Line (now 1px thick) */
-            box-shadow:
-                /* Glows start 1px below the top (at the bottom edge of the 1px high ::before element) */
-                0 1px 30px 10px rgba(0, 0, 0, 0.9),  /* Black Glow */
-                0 1px 60px 15px rgba(0, 0, 0, 0.85); /* Wider Black Glow */
-        }
-
-        /* Snowflake Styles */
-        .bouncing-snowflake {
-            position: absolute;
-            width: 50px; /* Smaller than Kazu images */
-            height: auto; /* Maintain aspect ratio */
-            z-index: 1; /* Same layer as Kazu bouncers */
-            opacity: 0; /* Start fully transparent for fade-in */
-            visibility: hidden; /* Initially hide */
-            transition: opacity 0.5s ease-in-out; /* Transition for smooth fade-in */
-            transform: translateZ(0); /* Attempt to promote to its own rendering layer */
-        }
 
         /* Table of Contents Styles */
+        /* Table of Contents Styles */
+        #tableOfContents {
+            background-color: #C0C0C0;
+            border: 2px solid;
+            border-top-color: #FFFFFF;
+            border-left-color: #FFFFFF;
+            border-bottom-color: #808080;
+            border-right-color: #808080;
+            box-shadow: none;
+            border-radius: 0;
+            transition: opacity 0.6s ease-out, transform 0.6s ease-out; /* Keep existing transition */
+        }
+        #tableOfContents h3 { /* Assuming h3 is "Contents" title */
+            color: #000000;
+            border-bottom-color: #808080; /* Match border style */
+        }
+        #tableOfContents ul li a {
+            /* color: #0000FF; /* Standard link blue - will be inherited from general <a> */
+            /* text-decoration: underline; */ /* Will be inherited */
+            /* background-color: transparent; */ /* Ensure no conflicting bg */
+        }
         .active-toc-link {
-            background-color: #4f46e5; /* indigo-600 */
-            color: white !important;
-            font-weight: 500; /* semibold */
-            
+            background-color: #808080 !important; /* Gray background for active */
+            color: #FFFFFF !important; /* White text for active */
+            font-weight: bold; /* Make active link bold */
+            text-decoration: none !important; /* Remove underline for active link */
         }
         #tableOfContents::-webkit-scrollbar {
-            width: 6px;
+            width: 16px; /* Wider scrollbar like Win95 */
         }
         #tableOfContents::-webkit-scrollbar-track {
-            background: rgba(51, 65, 85, 0.5); /* slate-700 with opacity */
-            border-radius: 3px;
+            background: #C0C0C0; /* Silver track */
         }
         #tableOfContents::-webkit-scrollbar-thumb {
-            background: #64748b; /* slate-500 */
-            border-radius: 3px;
+            background: #A0A0A0; /* Darker gray thumb */
+            border: 1px solid;
+            border-top-color: #FFFFFF;
+            border-left-color: #FFFFFF;
+            border-bottom-color: #808080;
+            border-right-color: #808080;
         }
         #tableOfContents::-webkit-scrollbar-thumb:hover {
-            background: #4f46e5; /* indigo-600 */
+            background: #808080; /* Even darker on hover */
         }
 
-        /* Add these styles to your styles/main.css file */
+        /* Table of Contents fade-in styles */
+        #tableOfContents.toc-is-loading {
+            opacity: 0;
+            transform: translateY(-15px);
+        }
 
-/* Table of Contents fade-in styles */
-#tableOfContents {
-    /* Define the transition property on the element itself */
-    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
-    /* Default state when visible and not 'loading' (opacity 1 is default for visible elements) */
-    /* transform: translateY(0); /* Default transform state */
-}
-
-#tableOfContents.toc-is-loading {
-    /* Initial state before fade-in */
-    opacity: 0;
-    transform: translateY(-15px); /* Start slightly above and fade/drop in */
-    /* pointer-events: none; /* Optional: prevent interaction while loading/invisible */
-}
+        /* Footer styling */
+        footer {
+            /* Assuming footer is outside .container, on the main body background */
+            color: #000000; /* Black text for readability on teal */
+            padding: 1rem;
+            text-align: center;
+        }
+        footer p {
+            margin: 0;
+        }


### PR DESCRIPTION
This commit revamps the website's appearance to emulate the classic Windows 95 desktop aesthetic.

Key changes include:

- Background: Changed to the iconic Windows 95 teal (#008080).
- Font: Default font changed to Arial, removing Google Fonts.
- UI Elements:
    - Buttons, containers, modals, and other UI components are styled with the characteristic 3D chiseled borders (outset/inset) and silver (#C0C0C0) backgrounds.
    - Text colors updated to primarily black for better readability on new backgrounds.
    - Links styled in classic blue with underlines.
- Removed/Simplified Modern Features:
    - Removed Tailwind CSS classes related to rounded corners, shadows, modern colors, and complex layouts that conflicted with the Windows 95 look.
    - Hid dynamic elements like bouncing logos and snowflakes that did not fit the retro theme.
    - Simplified or removed modern CSS effects such as screen edge glows and complex animations on elements like the back-to-top button.
    - Adjusted styling for interactive elements like the Table of Contents, Discord dropdown, and story displays to match the new theme.

The overall goal was to create a nostalgic user experience reminiscent of Windows 95 while maintaining the website's core functionality and content structure.