### PR TITLE
Change "Local time" label to "UK time"

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
       <section class="stat-grid">
         <div class="card stat-card">
           <div class="stat-bg-icon">🕒</div>
-          <div class="stat-label">Local time</div>
+          <div class="stat-label">UK time</div>
           <div class="stat-value" id="liveTime">--:--:--</div>
           <div class="stat-sub" id="liveDate">—</div>
         </div>


### PR DESCRIPTION
## Summary
- Renamed the "Local time" stat label to "UK time" since the clock is hardcoded to `Europe/London` regardless of viewer location.

## Test plan
- [x] Verified `TIMEZONE` constant in `script.js` is `Europe/London`
- [ ] Visually confirm label renders correctly on the live page

---
_Generated by [Claude Code](https://claude.ai/code/session_012JLMxSoC3LbaDcrVtV94Zy)_